### PR TITLE
CI: auto-merge safe Dependabot updates

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,40 @@
+name: Dependabot Auto Merge
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    if: >
+      github.actor == 'dependabot[bot]' &&
+      github.event.pull_request.base.ref == 'main' &&
+      github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge for safe updates
+        if: >
+          steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
+          steps.metadata.outputs.update-type == 'version-update:semver-minor'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh pr merge --auto --squash "${{ github.event.pull_request.number }}"
+
+      - name: Note skipped major update
+        if: >
+          steps.metadata.outputs.update-type == 'version-update:semver-major'
+        run: echo "Major dependency update detected. Leaving PR for manual review."

--- a/README.md
+++ b/README.md
@@ -124,6 +124,13 @@ GitHub Actions is configured to run on every push to `main` and every pull reque
 
 Dependabot is also configured for weekly updates for Composer, npm, and GitHub Actions dependencies.
 
+Dependabot auto-merge is enabled for safe updates:
+- only PRs opened by Dependabot
+- only into `main`
+- only patch/minor version updates
+- major updates require manual review
+- merge happens only after required status checks pass (branch protection)
+
 ## Deployment (IONOS)
 
 A deployment workflow is included at `.github/workflows/deploy-ionos.yml`.


### PR DESCRIPTION
## Summary
- add Dependabot auto-merge workflow
- auto-merge only for Dependabot PRs targeting `main`
- allow only semver patch/minor updates to auto-merge
- leave semver major updates for manual review
- update README with the auto-merge policy

## Safety model
- auto-merge is enabled with `gh pr merge --auto --squash`
- required status checks and branch protection still gate final merge
- deployment remains triggered by merges to `main`