### PR TITLE
Fix Dependabot auto-merge workflow repo context

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -32,7 +32,7 @@ jobs:
           steps.metadata.outputs.update-type == 'version-update:semver-minor'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh pr merge --auto --squash "${{ github.event.pull_request.number }}"
+        run: gh pr merge -R "${{ github.repository }}" --auto --squash "${{ github.event.pull_request.number }}"
 
       - name: Note skipped major update
         if: >


### PR DESCRIPTION
## Summary
- fix Dependabot auto-merge workflow failing with `fatal: not a git repository`
- pass explicit repository to gh CLI with `-R "${{ github.repository }}"`

## Why
The auto-merge job runs without a checkout, so gh cannot infer repository context from local git metadata unless `-R` is provided.

## Validation
- confirmed failing runs for PRs #11, #12, #13, #14 all errored with `fatal: not a git repository`
- YAML parses successfully after change
