### PR TITLE
Add applicants application year filter

### DIFF
--- a/app/Filament/Resources/ApplicantResource.php
+++ b/app/Filament/Resources/ApplicantResource.php
@@ -14,7 +14,10 @@ use Filament\Notifications\Notification;
 use Filament\Resources\Resource;
 use Filament\Actions;
 use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Filters\SelectFilter;
 use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Collection;
 
 class ApplicantResource extends Resource
 {
@@ -128,6 +131,44 @@ class ApplicantResource extends Resource
                     ->searchable()
                     ->sortable()
                     ->toggleable(isToggledHiddenByDefault: true),
+            ])
+            ->filters([
+                SelectFilter::make('application_year')
+                    ->label('Application Year')
+                    ->default((string) now()->year)
+                    ->placeholder('All years')
+                    ->options(function (): array {
+                        $driver = Applicant::query()->getConnection()->getDriverName();
+                        $currentYear = (string) now()->year;
+                        $yearExpression = match ($driver) {
+                            'sqlite' => "strftime('%Y', application_date)",
+                            'pgsql' => 'EXTRACT(YEAR FROM application_date)::text',
+                            default => 'YEAR(application_date)',
+                        };
+
+                        $years = Applicant::query()
+                            ->whereNotNull('application_date')
+                            ->selectRaw("{$yearExpression} as year")
+                            ->distinct()
+                            ->pluck('year', 'year')
+                            ->filter()
+                            ->mapWithKeys(fn (mixed $year): array => [(string) $year => (string) $year])
+                            ->all();
+
+                        $years[$currentYear] ??= $currentYear;
+                        krsort($years);
+
+                        return $years;
+                    })
+                    ->query(function (Builder $query, array $data): void {
+                        $year = $data['value'] ?? null;
+
+                        if (blank($year)) {
+                            return;
+                        }
+
+                        $query->whereYear('application_date', (int) $year);
+                    }),
             ])
             ->recordUrl(fn($record) => route('filament.admin.resources.applicants.edit', $record))
             ->bulkActions([

--- a/tests/Feature/ApplicantResourceYearFilterTest.php
+++ b/tests/Feature/ApplicantResourceYearFilterTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Filament\Resources\ApplicantResource\Pages\ListApplicants;
+use App\Models\Applicant;
+use App\Models\User;
+use Database\Seeders\ShieldSeeder;
+use Filament\Facades\Filament;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Gate;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class ApplicantResourceYearFilterTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->withoutVite();
+        Filament::setCurrentPanel(Filament::getPanel('admin'));
+    }
+
+    public function test_applicants_default_to_current_application_year_and_can_be_filtered(): void
+    {
+        $admin = $this->seedAndGetAdmin();
+        $currentYear = now()->year;
+        $previousYear = $currentYear - 1;
+
+        $currentYearApplicant = Applicant::factory()->create([
+            'name' => 'Current Year Applicant',
+            'application_date' => now()->setYear($currentYear)->toDateString(),
+        ]);
+        $secondCurrentYearApplicant = Applicant::factory()->create([
+            'name' => 'Second Current Year Applicant',
+            'application_date' => now()->setYear($currentYear)->subMonth()->toDateString(),
+        ]);
+        $previousYearApplicant = Applicant::factory()->create([
+            'name' => 'Previous Year Applicant',
+            'application_date' => now()->setYear($previousYear)->toDateString(),
+        ]);
+
+        $this->withoutMiddleware();
+        Gate::before(static fn () => true);
+        $this->actingAs($admin);
+
+        Livewire::test(ListApplicants::class)
+            ->assertTableFilterExists('application_year')
+            ->assertCanSeeTableRecords([$currentYearApplicant, $secondCurrentYearApplicant])
+            ->assertCanNotSeeTableRecords([$previousYearApplicant])
+            ->filterTable('application_year', (string) $previousYear)
+            ->assertCanSeeTableRecords([$previousYearApplicant])
+            ->assertCanNotSeeTableRecords([$currentYearApplicant, $secondCurrentYearApplicant])
+            ->filterTable('application_year', '')
+            ->assertCanSeeTableRecords([$currentYearApplicant, $secondCurrentYearApplicant, $previousYearApplicant]);
+    }
+
+    private function seedAndGetAdmin(): User
+    {
+        $this->seed(ShieldSeeder::class);
+
+        return User::query()
+            ->where('email', 'admin@example.com')
+            ->firstOrFail();
+    }
+}


### PR DESCRIPTION
## Summary
- add an application year select filter to the applicants table
- default the applicants list to the current year and allow switching to all years
- cover the filter behaviour with a Filament page test

## Testing
- APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=$(mktemp /tmp/club-backoffice-suite.XXXXXX) CACHE_STORE=array SESSION_DRIVER=array QUEUE_CONNECTION=sync MAIL_MAILER=array php artisan test
- npm run build

Closes #55