### PR TITLE
Truncate preferred position in applicants list

### DIFF
--- a/app/Filament/Resources/ApplicantResource.php
+++ b/app/Filament/Resources/ApplicantResource.php
@@ -103,6 +103,8 @@ class ApplicantResource extends Resource
                 TextColumn::make('preferred_position')
                     ->searchable()
                     ->sortable()
+                    ->limit(30)
+                    ->tooltip(fn (?string $state): ?string => filled($state) ? $state : null)
                     ->toggleable(),
                 TextColumn::make('preferred_foot')
                     ->searchable()

--- a/tests/Feature/ApplicantResourceYearFilterTest.php
+++ b/tests/Feature/ApplicantResourceYearFilterTest.php
@@ -9,6 +9,7 @@ use Database\Seeders\ShieldSeeder;
 use Filament\Facades\Filament;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\Str;
 use Livewire\Livewire;
 use Tests\TestCase;
 
@@ -56,6 +57,33 @@ class ApplicantResourceYearFilterTest extends TestCase
             ->assertCanNotSeeTableRecords([$currentYearApplicant, $secondCurrentYearApplicant])
             ->filterTable('application_year', '')
             ->assertCanSeeTableRecords([$currentYearApplicant, $secondCurrentYearApplicant, $previousYearApplicant]);
+    }
+
+    public function test_preferred_position_is_truncated_in_the_applicants_table_with_full_value_in_tooltip(): void
+    {
+        $admin = $this->seedAndGetAdmin();
+        $longPreferredPosition = 'Left wing / attacking midfielder / secondary striker rotation';
+
+        $applicant = Applicant::factory()->create([
+            'preferred_position' => $longPreferredPosition,
+        ]);
+
+        $this->withoutMiddleware();
+        Gate::before(static fn () => true);
+        $this->actingAs($admin);
+
+        Livewire::test(ListApplicants::class)
+            ->assertCanSeeTableRecords([$applicant])
+            ->assertTableColumnFormattedStateSet(
+                'preferred_position',
+                Str::limit($longPreferredPosition, 30),
+                $applicant,
+            )
+            ->assertTableColumnExists(
+                'preferred_position',
+                fn ($column): bool => $column->getTooltip($column->getState()) === $longPreferredPosition,
+                $applicant,
+            );
     }
 
     private function seedAndGetAdmin(): User


### PR DESCRIPTION
## Summary
- truncate long preferred position values in the applicants list table
- keep the full value available in a tooltip so the UI stays compact without hiding data
- add focused coverage for the truncated display and tooltip behavior

## Testing
- DB_CONNECTION=sqlite DB_DATABASE=/tmp/... php artisan test tests/Feature/ApplicantResourceYearFilterTest.php